### PR TITLE
Remove pandas dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 isodate==0.5.0
-pandas==0.13.1
 -e git+https://github.com/etalab/biryani.git@biryani1#egg=Biryani1
 -e git+https://github.com/openfisca/openfisca-core.git#egg=OpenFisca-Core
 -e git+https://github.com/openfisca/openfisca-france.git#egg=OpenFisca-France


### PR DESCRIPTION
Hi!

Pandas is no longer required.
Now build on Heroku takes less than 1 minute!

Enjoy!
