### PR TITLE
Remove unmatchable dependency

### DIFF
--- a/development-france.ini
+++ b/development-france.ini
@@ -19,9 +19,6 @@ use = egg:OpenFisca-Web-API
 cache_dir = %(here)s/cache
 country_package = openfisca_france
 log_level = DEBUG
-reforms =
-  landais_piketty_saez = openfisca_france_reform_landais_piketty_saez.build_reform
-  plfrss2014 = openfisca_france.reforms.plfrss2014.build_reform
 
 
 # Logging configuration

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.1',
         'OpenFisca-Core >= 0.4dev',
-        'OpenFisca-France-Reform-Landais-Piketty-Saez',
         'WebError >= 0.10',
         'WebOb >= 1.1',
         ],


### PR DESCRIPTION
See #7 (this won't fix the installation though, there are other unmatchable dependencies).

Another way of correcting the problem would be to allow the dependency to be matched by adding [installation instructions](http://www.openfisca.fr/installation) or, better, automate install.