### PR TITLE
Improve router (no CORS factorisation)

### DIFF
--- a/openfisca_web_api/urls.py
+++ b/openfisca_web_api/urls.py
@@ -82,29 +82,6 @@ def get_url(ctx, *path, **query):
         ('?' + urllib.urlencode(query, doseq = True)) if query else '')
 
 
-# def iter_full_urls(ctx, *path, **query):
-#     assert application_url is not None
-#     host_urls = conf['host_urls']
-#     if host_urls is None:
-#         yield get_full_url(ctx, *path, **query)
-#     else:
-#         path = [
-#             urllib.quote(unicode(sub_fragment).encode('utf-8'), safe = ',/:').decode('utf-8')
-#             for fragment in urlparse.urlsplit(application_url).path.split('/') + path
-#             if fragment
-#             for sub_fragment in unicode(fragment).split(u'/')
-#             if sub_fragment
-#             ]
-#         query = dict(
-#             (str(name), strings.deep_encode(value))
-#             for name, value in sorted(query.iteritems())
-#             if value not in (None, [], (), '')
-#             )
-#         for host_url in host_urls:
-#             yield u'{0}{1}{2}'.format(host_url, u'/'.join(path),
-#                 ('?' + urllib.urlencode(query, doseq = True)) if query else '')
-
-
 def make_router(*routings):
     """Return a WSGI application that dispatches requests to controllers """
     routes = []

--- a/openfisca_web_api/urls.py
+++ b/openfisca_web_api/urls.py
@@ -95,12 +95,13 @@ def make_router(*routings):
     def router(environ, start_response):
         """Dispatch request to controllers."""
         req = webob.Request(environ)
+        ctx = contexts.Ctx(req)
+        headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
+
         split_path_info = req.path_info.split('/')
         if split_path_info[0]:
             # When path_info doesn't start with a "/" this is an error or a attack => Reject request.
             # An example of an URL with such a invalid path_info: http://127.0.0.1http%3A//127.0.0.1%3A80/result?...
-            ctx = contexts.Ctx(req)
-            headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
             return wsgihelpers.respond_json(ctx,
                 dict(
                     apiVersion = 1,
@@ -111,19 +112,31 @@ def make_router(*routings):
                     ),
                 headers = headers,
                 )(environ, start_response)
+
         for methods, regex, app, vars in routes:
-            if methods is None or req.method in methods:
-                match = regex.match(req.path_info)
-                if match is not None:
-                    if getattr(req, 'urlvars', None) is None:
-                        req.urlvars = {}
-                    req.urlvars.update(match.groupdict())
-                    req.urlvars.update(vars)
-                    req.script_name += req.path_info[:match.end()]
-                    req.path_info = req.path_info[match.end():]
-                    return app(req.environ, start_response)
-        ctx = contexts.Ctx(req)
-        headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
+            match = regex.match(req.path_info)
+            if match is not None:
+                if methods is not None and req.method not in methods:
+                    return wsgihelpers.respond_json(ctx,
+                        dict(
+                            apiVersion = 1,
+                            error = dict(
+                                code = 405,
+                                message = ctx._(u"You cannot use HTTP {} to access this URL. Use one of {}.")
+                                             .format(req.method, methods),
+                                ),
+                            ),
+                        headers = headers,
+                        )(environ, start_response)
+
+                if getattr(req, 'urlvars', None) is None:
+                    req.urlvars = {}
+                req.urlvars.update(match.groupdict())
+                req.urlvars.update(vars)
+                req.script_name += req.path_info[:match.end()]
+                req.path_info = req.path_info[match.end():]
+                return app(req.environ, start_response)
+
         return wsgihelpers.respond_json(ctx,
             dict(
                 apiVersion = 1,

--- a/openfisca_web_api/urls.py
+++ b/openfisca_web_api/urls.py
@@ -96,12 +96,12 @@ def make_router(*routings):
         """Dispatch request to controllers."""
         req = webob.Request(environ)
         ctx = contexts.Ctx(req)
-        headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
 
         split_path_info = req.path_info.split('/')
         if split_path_info[0]:
             # When path_info doesn't start with a "/" this is an error or a attack => Reject request.
             # An example of an URL with such a invalid path_info: http://127.0.0.1http%3A//127.0.0.1%3A80/result?...
+            headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
             return wsgihelpers.respond_json(ctx,
                 dict(
                     apiVersion = 1,
@@ -117,6 +117,7 @@ def make_router(*routings):
             match = regex.match(req.path_info)
             if match is not None:
                 if methods is not None and req.method not in methods:
+                    headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
                     return wsgihelpers.respond_json(ctx,
                         dict(
                             apiVersion = 1,
@@ -137,6 +138,7 @@ def make_router(*routings):
                 req.path_info = req.path_info[match.end():]
                 return app(req.environ, start_response)
 
+        headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
         return wsgihelpers.respond_json(ctx,
             dict(
                 apiVersion = 1,

--- a/openfisca_web_api/wsgihelpers.py
+++ b/openfisca_web_api/wsgihelpers.py
@@ -40,8 +40,8 @@ N_ = lambda message: message
 
 
 errors_title = {
-    400: N_("Unable to Access"),
-    401: N_("Access Denied"),
+    400: N_("Bad Request"),
+    401: N_("Unauthorized"),
     403: N_("Access Denied"),
     404: N_("Unable to Access"),
     }


### PR DESCRIPTION
This is the same PR as #12, only without factorisation of `headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)` due to possible side-effects if we didn't want to handle CORS in all cases, as per @eraviart’s instructions.

Please choose between this PR and #12.