### PR TITLE
Return a proper JSON 500 in unexpected /formula failure

### DIFF
--- a/openfisca_web_api/controllers/formula.py
+++ b/openfisca_web_api/controllers/formula.py
@@ -95,7 +95,15 @@ On a server, just test what your library handles.
             data['values'][formula_name] = compute(column.name, params, data['period'])
 
     except Exception as error:
-        data['error'] = error.args[0]
+        if isinstance(error.args[0], dict):  # we raised it ourselves, in this controller
+            error = error.args[0]
+        else:
+            error = dict(
+                message = unicode(error),
+                code = 500
+                )
+
+        data['error'] = error
     finally:
         return respond(req, API_VERSION, data, params)
 


### PR DESCRIPTION
Rather than a plaintext `Internal Server Error`.
See #24 for why it is not in the main responder.