### PR TITLE
Allow computing year-dependent formulas in /formula

### DIFF
--- a/openfisca_web_api/controllers/formula.py
+++ b/openfisca_web_api/controllers/formula.py
@@ -161,13 +161,21 @@ def parse_period(period_descriptor):
     period_descriptor = period_descriptor or default_period()
 
     try:
-        return periods.period(period_descriptor)
+        result = periods.period(period_descriptor)
     except ValueError:
         raise(Exception(dict(
             code = 400,
             message = u"You requested computation for period '{}', but it could not be parsed as a period"
                       .format(period_descriptor)
             )))
+
+    if result.unit not in ['year', 'month']:
+        raise Exception(dict(
+            code = 400,
+            message = u"You passed period '{}', but it is not a month nor a year".format(period_descriptor)
+            ))
+
+    return result
 
 
 def default_period():
@@ -224,11 +232,22 @@ def create_simulation(data, period):
             holder.set_array(period, np.array([0]))
             holder = persons.get_or_new_holder(entity.role_for_person_variable_name)
             holder.set_array(period, np.array([0]))
+
     # Inject all variables from query string into arrays.
     for column_name, value in data.iteritems():
         column = model.tax_benefit_system.column_by_name[column_name]
         entity = result.entity_by_key_plural[column.entity_key_plural]
         holder = entity.get_or_new_holder(column_name)
-        holder.set_array(period, np.array([value], dtype = column.dtype))
+
+        if period.unit == 'year':
+            holder.set_array(period, np.array([value], dtype = column.dtype))
+        elif period.unit == 'month':
+            # Inject inputs for all months of year
+            year = period.start.year
+            month_index = 1
+            while month_index <= 12:
+                month = periods.period('{}-{:02d}'.format(year, month_index))
+                holder.set_array(month, np.array([value], dtype = column.dtype))
+                month_index += 1
 
     return result

--- a/openfisca_web_api/controllers/formula.py
+++ b/openfisca_web_api/controllers/formula.py
@@ -78,7 +78,7 @@ If used within the browser, make sure the resulting URL is kept
 for cross-browser compatibility, by splitting combined requests.
 On a server, just test what your library handles.
 """
-    API_VERSION = '2.0.0-alpha.1'
+    API_VERSION = '2.1.0'
     params = dict(req.GET)
     data = dict()
 

--- a/openfisca_web_api/tests/test_formula_2.py
+++ b/openfisca_web_api/tests/test_formula_2.py
@@ -34,6 +34,7 @@ from . import common
 TARGET_URL = '/api/2/formula/'
 INPUT_VARIABLE = 'salaire_de_base'
 VALID_PERIOD = '2015-01'
+VALID_DAY = VALID_PERIOD + '-01'
 INVALID_PERIOD = 'herp'
 VALID_FORMULA = 'salaire_net_a_payer'
 DATED_FORMULA = 'allegement_fillon'
@@ -209,4 +210,17 @@ def test_invalid_period_error_message():
 
     assert_in(INVALID_PERIOD, message)
     assert_in('could not be parsed', message)
+    assert_not_in('{', message)  # serialisation failed
+
+
+def test_invalid_period_day_status_code():
+    assert_equal(send(period = VALID_DAY)['status_code'], 400)
+
+
+def test_invalid_period_day_error_message():
+    message = send(period = VALID_DAY)['payload']['error']['message']
+
+    assert_in(VALID_DAY, message)
+    assert_in('year', message)
+    assert_in('month', message)
     assert_not_in('{', message)  # serialisation failed

--- a/openfisca_web_api/tests/test_formula_2.py
+++ b/openfisca_web_api/tests/test_formula_2.py
@@ -83,7 +83,7 @@ def test_formula_delete_status_code():
 
 
 def test_formula_api_version():
-    assert_equal(send()['payload']['apiVersion'], '2.0.0-alpha.1')
+    assert_equal(send()['payload']['apiVersion'], '2.1.0')
 
 
 def test_dated_formula_status_code():


### PR DESCRIPTION
Keep assumption of “one month computation”, but set data for the full year.