### PR TITLE
Reforms in formula endpoint

### DIFF
--- a/development-france.ini
+++ b/development-france.ini
@@ -19,6 +19,7 @@ use = egg:OpenFisca-Web-API
 country_package = openfisca_france
 log_level = DEBUG
 reforms =
+; openfisca_france.reforms.de_net_a_brut.build_reform
 ; openfisca_france_reform_landais_piketty_saez.build_reform
 ; openfisca_france_reform_revenu_de_base_cotisations.build_reform
 ; openfisca_france_reform_revenu_de_base_enfants.build_reform

--- a/openfisca_web_api/controllers/formula.py
+++ b/openfisca_web_api/controllers/formula.py
@@ -41,10 +41,10 @@ You can compute several formulas at once by combining the paths and joining them
 
 Example:
 ```
-/salsuperbrut+salaire_net_a_payer?salaire_de_base=1440
+/salaire_super_brut+salaire_net_a_payer?salaire_de_base=1440
 ```
 
-This will compute both `salsuperbrut` and `salaire_net_a_payer` in a single request.
+This will compute both `salaire_super_brut` and `salaire_net_a_payer` in a single request.
 
 
 URL size limit

--- a/openfisca_web_api/model.py
+++ b/openfisca_web_api/model.py
@@ -19,6 +19,9 @@ TaxBenefitSystem = None
 
 
 def get_cached_composed_reform(reform_keys, tax_benefit_system):
+    if reform_by_full_key is None:
+        raise Exception('Cannot use reforms when none has been loaded in the instance configuration')\
+
     full_key = '.'.join(
         [tax_benefit_system.full_key] + reform_keys
         if isinstance(tax_benefit_system, reforms.AbstractReform)


### PR DESCRIPTION
Enable the use of reforms in the /formula endpoint

To keep this endpoint URL simple, they are requested as a list in a custom HTTP header.
```
X-OpenFisca-Extensions: de_net_a_brut, landais_piketty_saez
```
This header is of course optional.