### PR TITLE
Don't use git sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 – [diff](https://github.com/openfisca/openfisca-web-api/compare/1.0.0...1.0.1)
+
+* Use package version instead of git sha.
+
 ## 1.0.0 – [diff](https://github.com/openfisca/openfisca-web-api/compare/0.5.2...1.0.0)
 
 * Switch to [semantic versioning](http://semver.org/)

--- a/openfisca_web_api/application.py
+++ b/openfisca_web_api/application.py
@@ -74,7 +74,7 @@ def x_api_version_header_setter(app):
     def set_x_api_version_header(environ, start_response):
         req = webob.Request(environ)
         res = req.get_response(app)
-        res.headers.update({'X-API-Version': environment.git_head_sha})
+        res.headers.update({'X-API-Version': environment.api_package_version})
         return res(environ, start_response)
 
     return set_x_api_version_header

--- a/openfisca_web_api/controllers/parameters.py
+++ b/openfisca_web_api/controllers/parameters.py
@@ -101,7 +101,7 @@ def api1_parameters(req):
 
     response_dict = dict(
         apiVersion = 1,
-        country_package_git_head_sha = environment.country_package_git_head_sha,
+        country_package_version = environment.country_package_version,
         method = req.script_name,
         parameters = parameters_json,
         url = req.url.decode('utf-8'),

--- a/openfisca_web_api/controllers/variables.py
+++ b/openfisca_web_api/controllers/variables.py
@@ -83,7 +83,7 @@ def api1_variables(req):
     return wsgihelpers.respond_json(ctx,
         collections.OrderedDict(sorted(dict(
             apiVersion = 1,
-            country_package_git_head_sha = environment.country_package_git_head_sha,
+            country_package_version= environment.country_package_version,
             method = req.script_name,
             url = req.url.decode('utf-8'),
             variables = variables_json,

--- a/openfisca_web_api/environment.py
+++ b/openfisca_web_api/environment.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
-
 """Environment configuration"""
-
 
 import collections
 import datetime
@@ -11,7 +9,6 @@ import logging
 import multiprocessing
 import os
 import pkg_resources
-import subprocess
 import sys
 import weakref
 
@@ -29,18 +26,13 @@ app_dir = os.path.dirname(os.path.abspath(__file__))
 
 # Initialized in load_environment.
 country_package_dir_path = None
-country_package_git_head_sha = None
+country_package_version = None
+api_package_version = None
 cpu_count = None
-git_head_sha = None
 
 
 class ValueAndError(list):  # Can't be a tuple subclass, because WeakValueDictionary doesn't work with (sub)tuples.
     pass
-
-
-def get_git_head_sha(cwd = os.path.dirname(__file__)):
-    output = subprocess.check_output(['git', 'rev-parse', '--verify', 'HEAD'], cwd=cwd)
-    return output.rstrip('\n')
 
 
 def get_relative_file_path(absolute_file_path, base_path):
@@ -170,11 +162,11 @@ def load_environment(global_conf, app_conf):
     global country_package_dir_path
     country_package_dir_path = pkg_resources.get_distribution(conf['country_package']).location
 
-    # Store Git last commit SHA
-    global git_head_sha
-    git_head_sha = get_git_head_sha()
-    global country_package_git_head_sha
-    country_package_git_head_sha = get_git_head_sha(cwd = country_package.__path__[0])
+    global api_package_version
+    api_package_version = pkg_resources.get_distribution('openfisca_web_api').version
+
+    global country_package_version
+    country_package_version = pkg_resources.get_distribution(conf["country_package"]).version
 
     # Cache legislation JSON with references to original XML
     legislation_json_with_references_to_xml = tax_benefit_system.get_legislation_json(with_source_file_infos = True)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ previous = true
 hang-closing = true
 ; E128 continuation line under-indented for visual indent
 ; E251 unexpected spaces around keyword / parameter equals
-ignore = E128,E251
+; F405 name may be undefined, or defined from star imports: module
+ignore = E128,E251,F405
 ;max-complexity = 10
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '1.0.0',
+    version = '1.0.1',
 
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',


### PR DESCRIPTION
As it prevents the api from working out of a git repository.

Use the country package version instead, now that we have strict versioning.

Fixes the build.