### PR TITLE
Add openfisca-serve CLI script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 – [diff](https://github.com/openfisca/openfisca-web-api/compare/1.0.4...1.1.0)
+
+* Add openfisca-serve CLI script to quickly launch the api with a basic conf
+
 ## 1.0.4 – [diff](https://github.com/openfisca/openfisca-web-api/compare/1.0.3...1.0.4)
 
 * Update numpy dependency to 1.11

--- a/openfisca_web_api/scripts/serve.py
+++ b/openfisca_web_api/scripts/serve.py
@@ -15,6 +15,13 @@ port = 2000
 
 def main():
     conf_file_path = os.path.join(sys.prefix, 'share', 'openfisca', 'openfisca-web-api', 'development-france.ini')
+
+    # If openfisca_web_api has been installed with --editable
+    if not os.path.isfile(conf_file_path):
+        import pkg_resources
+        api_sources_path = pkg_resources.get_distribution("openfisca_web_api").location
+        conf_file_path = os.path.join(api_sources_path, 'development-france.ini')
+
     fileConfig(conf_file_path)
     application = loadapp('config:{}'.format(conf_file_path))
     httpd = make_server(hostname, port, application)

--- a/openfisca_web_api/scripts/serve.py
+++ b/openfisca_web_api/scripts/serve.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 
-
 import os
 import sys
+import argparse
 from logging.config import fileConfig
 from wsgiref.simple_server import make_server
 
 from paste.deploy import loadapp
 
 
-hostname = 'localhost'
-port = 2000
-
-
 def main():
+    parser = argparse.ArgumentParser(description = __doc__)
+    parser.add_argument('-p', '--port', action = 'store', default = 2000, help = "port to serve on")
+    args = parser.parse_args()
+
+    port = int(args.port)
+    hostname = 'localhost'
     conf_file_path = os.path.join(sys.prefix, 'share', 'openfisca', 'openfisca-web-api', 'development-france.ini')
 
     # If openfisca_web_api has been installed with --editable

--- a/openfisca_web_api/scripts/serve.py
+++ b/openfisca_web_api/scripts/serve.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+
+import os
+import sys
+from logging.config import fileConfig
+from wsgiref.simple_server import make_server
+
+from paste.deploy import loadapp
+
+
+hostname = 'localhost'
+port = 2000
+
+
+def main():
+    conf_file_path = os.path.join(sys.prefix, 'share', 'openfisca', 'openfisca-web-api', 'development-france.ini')
+    fileConfig(conf_file_path)
+    application = loadapp('config:{}'.format(conf_file_path))
+    httpd = make_server(hostname, port, application)
+    print u'Serving on http://{}:{}/'.format(hostname, port)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        return
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/openfisca_web_api/tests/test-cli.sh
+++ b/openfisca_web_api/tests/test-cli.sh
@@ -1,0 +1,3 @@
+openfisca-serve &
+
+wget --quiet --retry-connrefused --waitretry=1 --output-document=/dev/null http://localhost:2000

--- a/run-travis-tests.sh
+++ b/run-travis-tests.sh
@@ -43,3 +43,5 @@ fi
 
 
 make test
+
+bash openfisca_web_api/tests/test-cli.sh

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '1.0.4',
+    version = '1.1.0',
 
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         },
     install_requires = [
         'Babel >= 0.9.4',
-        'Biryani >= 0.10.4',
+        'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
         'OpenFisca-Core ~= 2.0.2',
         'OpenFisca-Parsers ~= 0.5.3',

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'paste.app_factory': 'main = openfisca_web_api.application:make_app',
         },
     extras_require = {
-        'dev': [
+        'paster': [
             'PasteScript',
             ],
         'france': [

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
             ),
         ],
     entry_points = {
+        'console_scripts': ['openfisca-serve=openfisca_web_api.scripts.serve:main'],
         'paste.app_factory': 'main = openfisca_web_api.application:make_app',
         },
     extras_require = {


### PR DESCRIPTION
We can now use:

```
$ openfisca-serve
16:29:48,884 INFO  [root] Generating grammar tables from /usr/lib/python2.7/lib2to3/Grammar.txt
16:29:48,920 INFO  [root] Generating grammar tables from /usr/lib/python2.7/lib2to3/PatternGrammar.txt
Serving on http://localhost:2000/
```

to start the Web API.
