### PR TITLE
Add extension loading in api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0 – [diff](https://github.com/openfisca/openfisca-web-api/compare/1.1.0...1.2.0)
+
+* Declare TBS extensions in configuration file
+
 ## 1.1.0 – [diff](https://github.com/openfisca/openfisca-web-api/compare/1.0.4...1.1.0)
 
 * Add openfisca-serve CLI script to quickly launch the api with a basic conf

--- a/development-france.ini
+++ b/development-france.ini
@@ -30,6 +30,8 @@ reforms =
 ; openfisca_france.reforms.plfr2014.plfr2014
 ; openfisca_france.reforms.trannoy_wasmer.trannoy_wasmer
 
+extensions =
+; openfisca_paris
 
 # Logging configuration
 [loggers]

--- a/openfisca_web_api/environment.py
+++ b/openfisca_web_api/environment.py
@@ -70,6 +70,7 @@ def load_environment(global_conf, app_conf):
             'package_name': conv.default('openfisca-web-api'),
             'realm': conv.default(u'OpenFisca Web API'),
             'reforms': conv.ini_str_to_list,  # Another validation is done below.
+            'extensions': conv.ini_str_to_list,
             },
         default = 'drop',
         ))(conf))
@@ -90,6 +91,11 @@ def load_environment(global_conf, app_conf):
     # Initialize tax-benefit system.
     country_package = importlib.import_module(conf['country_package'])
     tax_benefit_system = country_package.CountryTaxBenefitSystem()
+
+    extensions = conf['extensions']
+    if extensions is not None:
+        for extension in extensions:
+            tax_benefit_system.load_extension(extension)
 
     class Scenario(tax_benefit_system.Scenario):
         instance_and_error_couple_cache = {} if conf['debug'] else weakref.WeakValueDictionary()  # class attribute

--- a/openfisca_web_api/model.py
+++ b/openfisca_web_api/model.py
@@ -10,6 +10,7 @@ from openfisca_core.reforms import Reform, compose_reforms
 # Declarations, initialized in environment module
 
 reforms = None
+extensions = None
 decomposition_json_by_file_path_cache = {}
 input_variables_and_parameters_by_column_name_cache = {}
 input_variables_extractor = None

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '1.1.0',
+    version = '1.2.0',
 
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
@@ -57,8 +57,8 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core ~= 2.0.2',
-        'OpenFisca-Parsers ~= 0.5.3',
+        'OpenFisca-Core >= 2.1.0, < 3.0',
+        'OpenFisca-Parsers ~= 0.5.4',
         'PasteDeploy',
         'WebError >= 0.10',
         'WebOb >= 1.1',


### PR DESCRIPTION
Declare extensions to load in an openfisca instance in the api config file.

Depends on https://github.com/openfisca/openfisca-parsers/pull/17
Depends on https://github.com/openfisca/openfisca-core/pull/399