### PR TITLE
Fix run-travis-tests.sh to repair automatic pypi releasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1 – [diff](https://github.com/openfisca/openfisca-web-api/compare/1.2.0...1.2.1)
+
+* Fix run-travis-tests.sh to repair automatic pypi releasing
+
 ## 1.2.0 – [diff](https://github.com/openfisca/openfisca-web-api/compare/1.1.0...1.2.0)
 
 * Declare TBS extensions in configuration file

--- a/run-travis-tests.sh
+++ b/run-travis-tests.sh
@@ -35,7 +35,8 @@ function checkout {
 }
 
 
-if [ "$TRAVIS_BRANCH" != "master" ]; then
+if [[ "$TRAVIS_BRANCH" != "master" && -z "$TRAVIS_TAG" ]]
+then
   checkout "OpenFisca-Core"
   checkout "OpenFisca-France"
   checkout "OpenFisca-Parsers"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '1.2.0',
+    version = '1.2.1',
 
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',


### PR DESCRIPTION
The checkout system is causing trouble on builds following a tag release, which prevent automatic pip publication. 

This is a quick fix, but we should consider removing the whole system as we can have something more robust using just version numbers.