### PR TITLE
Fix venv wrong path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1
+
+* In some cases in `/variables` endpoint, `source_file_path` of each variable was wrong if application was deployed
+  in a virtualenv. This fix uses `importlib` to get the path of the country package instead of `pkg_resources`.
+
 ## 2.0.0
 
 * Update introspection data (via OpenFisca-Core update)

--- a/openfisca_web_api/environment.py
+++ b/openfisca_web_api/environment.py
@@ -156,7 +156,9 @@ def load_environment(global_conf, app_conf):
         model.input_variables_extractor = input_variables_extractors.setup(tax_benefit_system)
 
     global country_package_dir_path
-    country_package_dir_path = pkg_resources.get_distribution(conf['country_package']).location
+    # Using pkg_resources.get_distribution(conf["country_package"]).location
+    # returns a wrong path in virtualenvs (<venv>/lib versus <venv>/local/lib).
+    country_package_dir_path = country_package.__path__[0]
 
     global api_package_version
     api_package_version = pkg_resources.get_distribution('openfisca_web_api').version

--- a/openfisca_web_api/tests/test_variables.py
+++ b/openfisca_web_api/tests/test_variables.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+
+import json
+
+from nose.tools import assert_equal, assert_greater, assert_in, assert_is_instance
+from webob import Request
+
+from . import common
+
+
+def setup_module(module):
+    common.get_or_load_app()
+
+
+def test_basic_call():
+    req = Request.blank('/api/1/variables', method = 'GET')
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 200, res.body)
+    res_json = json.loads(res.body)
+    assert_is_instance(res_json, dict)
+    assert_in('country_package_name', res_json)
+    assert_in('country_package_version', res_json)
+    assert_in('variables', res_json)
+    assert_is_instance(res_json['variables'], list)
+
+    source_file_path = res_json['variables'][0]['source_file_path']
+    assert source_file_path.startswith('model'), source_file_path

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '2.0.0',
+    version = '2.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
In some cases in `/variables` endpoint, `source_file_path` of each variable was wrong if application was deployed in a virtualenv. This fix uses `importlib` to get the path of the country package instead of `pkg_resources`.
