### PR TITLE
Refactor middlewares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+* Refactor middlewares in order to send error emails *and* returning JSON with correct content-type.
+
 ## 2.0.2
 
 * Remove any mention to `conda` in README, since we use `pip` now.

--- a/openfisca_web_api/environment.py
+++ b/openfisca_web_api/environment.py
@@ -96,6 +96,7 @@ def load_environment(global_conf, app_conf):
         errorware['error_subject_prefix'] = conf.get('error_subject_prefix', 'OpenFisca Web API Error: ')
         errorware['from_address'] = conf['from_address']
         errorware['smtp_server'] = conf.get('smtp_server', 'localhost')
+        errorware['show_exceptions_in_wsgi_errors'] = conf.get('show_exceptions_in_wsgi_errors', True)
 
     # Initialize tax-benefit system.
     country_package = importlib.import_module(conf['country_package'])

--- a/openfisca_web_api/tests/test_variables.py
+++ b/openfisca_web_api/tests/test_variables.py
@@ -3,7 +3,7 @@
 
 import json
 
-from nose.tools import assert_equal, assert_greater, assert_in, assert_is_instance
+from nose.tools import assert_equal, assert_in, assert_is_instance
 from webob import Request
 
 from . import common

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '2.0.2',
+    version = '2.0.3',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
This fixes a case where email errors were sent but `application/json` content-type was not set.

This changes nothing for the caller.
