### PR TITLE
Adat web-api to core#v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.0
+
+* Adapt parsers to core#v4
+
+* Breaking change:
+    * Route /1/entities deprecated, replaced by /2/entities with different structure.
+
 ## 2.0.3
 
 * Refactor middlewares in order to send error emails *and* returning JSON with correct content-type.

--- a/openfisca_web_api/controllers/__init__.py
+++ b/openfisca_web_api/controllers/__init__.py
@@ -35,7 +35,7 @@ def make_router():
         ('GET', '^/$', index),
         ('GET', '^/api/?$', index),
         ('POST', '^/api/1/calculate/?$', calculate.api1_calculate),
-        ('GET', '^/api/1/entities/?$', entities.api1_entities),
+        ('GET', '^/api/2/entities/?$', entities.api1_entities),
         ('GET', '^/api/1/field/?$', field.api1_field),
         ('GET', '^/api/1/fields/?$', fields.api1_fields),
         ('GET', '^/api/1/formula/(?P<name>[^/]+)/?$', formula.api1_formula),

--- a/openfisca_web_api/controllers/calculate.py
+++ b/openfisca_web_api/controllers/calculate.py
@@ -404,7 +404,7 @@ def api1_calculate(req):
                 traceback_json.append(collections.OrderedDict(sorted(dict(
                     cell_type = column.val_type,  # Unification with OpenFisca Julia name.
                     default_input_variables = step.get('default_input_variables', False),
-                    entity = column.entity,
+                    entity = column.entity.key,
                     input_variables = [
                         (input_variable_name, str(input_variable_period))
                         for input_variable_name, input_variable_period in input_variables_infos

--- a/openfisca_web_api/controllers/calculate.py
+++ b/openfisca_web_api/controllers/calculate.py
@@ -51,7 +51,7 @@ def fill_test_cases_with_values(intermediate_variables, scenarios, simulations, 
             if variable_value_json is None:
                 continue
             variable_name = holder.column.name
-            entity_members = test_case[holder.entity.key_plural]
+            entity_members = test_case[holder.entity.plural]
             if isinstance(variable_value_json, dict):
                 for entity_member_index, entity_member in enumerate(entity_members):
                     entity_member[variable_name] = {}

--- a/openfisca_web_api/controllers/entities.py
+++ b/openfisca_web_api/controllers/entities.py
@@ -9,15 +9,13 @@ import collections
 from .. import contexts, conv, model, wsgihelpers
 
 
-def build_entity_data(entity_class):
-    entity_data = {'label': entity_class.label}
-    if entity_class.is_persons_entity:
-        entity_data['isPersonsEntity'] = entity_class.is_persons_entity
+def build_entity_data(entity):
+    entity_data = {'label': entity.label}
+    if entity.is_person:
+        entity_data['isPersonsEntity'] = entity.is_person
     else:
         entity_data.update({
-            'maxCardinalityByRoleKey': entity_class.max_cardinality_by_role_key,
-            'roles': entity_class.roles_key,
-            'labelByRoleKey': entity_class.label_by_role_key,
+            'roles': entity.roles_description,
             })
     return entity_data
 
@@ -70,10 +68,9 @@ def api1_entities(req):
         tax_benefit_system = country_tax_benefit_system,
         ) if data['reforms'] is not None else country_tax_benefit_system
 
-    entities_class = tax_benefit_system.entity_class_by_key_plural.itervalues()
     entities = {
-        entity_class.key_plural: build_entity_data(entity_class)
-        for entity_class in entities_class
+        entity.key: build_entity_data(entity)
+        for entity in tax_benefit_system.entities
         }
 
     return wsgihelpers.respond_json(ctx,

--- a/openfisca_web_api/controllers/field.py
+++ b/openfisca_web_api/controllers/field.py
@@ -91,7 +91,7 @@ def api1_field(req):
             get_input_variables_and_parameters = model.get_cached_input_variables_and_parameters,
             with_input_variables_details = True,
             )
-    value_json['entity'] = column.entity  # Overwrite with symbol instead of key plural for compatibility.
+    value_json['entity'] = column.entity.key  # Overwrite with symbol instead of key plural for compatibility.
 
     return wsgihelpers.respond_json(ctx,
         collections.OrderedDict(sorted(dict(

--- a/openfisca_web_api/controllers/fields.py
+++ b/openfisca_web_api/controllers/fields.py
@@ -12,7 +12,7 @@ from .. import contexts, conv, model, wsgihelpers
 
 def get_column_json(column):
     column_json = column.to_json()
-    column_json['entity'] = column.entity  # Overwrite with symbol instead of key plural for compatibility.
+    column_json['entity'] = column.entity.key  # Overwrite with symbol instead of key plural for compatibility.
     return column_json
 
 

--- a/openfisca_web_api/controllers/formula.py
+++ b/openfisca_web_api/controllers/formula.py
@@ -216,17 +216,16 @@ def create_simulation(data, period, tax_benefit_system):
         )
     # Initialize entities, assuming there is only one person and one of each other entities ("familles",
     # "foyers fiscaux", etc).
-    for entity in result.entity_by_key_plural.itervalues():
+    for entity in result.entities.itervalues():
         entity.count = 1
         entity.roles_count = 1
         entity.step_size = 1
     # Link person to its entities using ID & role.
-    for entity in result.entity_by_key_plural.itervalues():
-        if not entity.is_persons_entity:
-            holder = result.get_or_new_holder(entity.index_for_person_variable_name)
-            holder.put_in_cache(np.array([0]), period)
-            holder = result.get_or_new_holder(entity.role_for_person_variable_name)
-            holder.put_in_cache(np.array([0]), period)
+    for entity in result.entities.itervalues():
+        if not entity.is_person:
+            entity.members_entity_id = np.array([0])
+            entity.members_legacy_role = np.array([0])
+            entity.members_role = np.array([0])
 
     # Inject all variables from query string into arrays.
     for column_name, value in data.iteritems():

--- a/openfisca_web_api/tests/test_entities.py
+++ b/openfisca_web_api/tests/test_entities.py
@@ -11,6 +11,6 @@ def setup_module(module):
 
 
 def test_entities_without_parameters():
-    req = Request.blank('/api/1/entities', method = 'GET')
+    req = Request.blank('/api/2/entities', method = 'GET')
     res = req.get_response(common.app)
     assert res.status_code == 200

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
             'PasteScript',
             ],
         'france': [
-            'OpenFisca-France >= 4.0.3, < 5.0',
+            'OpenFisca-France >= 5.0.0, < 7.0',
             ],
         'test': [
             'nose',
@@ -56,8 +56,8 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core >= 3.0.0, < 4.0',
-        'OpenFisca-Parsers >= 0.5.4, < 1.0',
+        'OpenFisca-Core >= 4.0.0b1, < 5.0',
+        'OpenFisca-Parsers >= 1.0.0, < 2.0',
         'PasteDeploy',
         'WebError >= 0.10',
         'WebOb >= 1.1',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '2.0.3',
+    version = '3.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
The only breaking change is on route `/entities/`, but I don't know in which context this route was used.


## Before: 
```JSON
{
    "apiVersion": 1,
    "entities": {
        "familles": {
            "labelByRoleKey": {
                "parents": "Parents",
                "enfants": "Enfants"
            },
            "maxCardinalityByRoleKey": {
                "parents": 2
            },
            "roles": ["parents", "enfants"],
            "label": "Famille"
        },
        "foyers_fiscaux": {
            "labelByRoleKey": {
                "personnes_a_charge": "Personnes à charge",
                "declarants": "Déclarants"
            },
            "maxCardinalityByRoleKey": {
                "declarants": 2
            },
            "roles": ["declarants", "personnes_a_charge"],
            "label": "Déclaration d'impôt"
        },
        "individus": {
            "isPersonsEntity": true,
            "label": "Personne"
        },
        "menages": {
            "labelByRoleKey": {
                "conjoint": "Conjoint",
                "autres": "Autres",
                "enfants": "Enfants",
                "personne_de_reference": "Personne de référence"
            },
            "maxCardinalityByRoleKey": {
                "conjoint": 1,
                "personne_de_reference": 1
            },
            "roles": ["personne_de_reference", "conjoint", "enfants", "autres"],
            "label": "Logement principal"
        }
    },
    "method": "/api/1/entities",
    "params": {
        "context": null,
        "reforms": []
    }
}
```

## After: 

```JSON
{
    "apiVersion": 1,
    "entities": {
        "famille": {
            "roles": [{
                "subroles": ["demandeur", "conjoint"],
                "plural": "parents",
                "key": "parent",
                "label": "Parents"
            }, {
                "plural": "enfants",
                "key": "enfant",
                "label": "Enfants"
            }],
            "label": "Famille"
        },
        "foyer_fiscal": {
            "roles": [{
                "subroles": ["declarant_principal", "conjoint"],
                "plural": "declarants",
                "key": "declarant",
                "label": "Déclarants"
            }, {
                "plural": "personnes_a_charge",
                "key": "personne_a_charge",
                "label": "Personnes à charge"
            }],
            "label": "Déclaration d’impôts"
        },
        "individu": {
            "isPersonsEntity": true,
            "label": "Individu"
        },
        "menage": {
            "roles": [{
                "max": 1,
                "key": "personne_de_reference",
                "label": "Personne de référence"
            }, {
                "max": 1,
                "key": "conjoint",
                "label": "Conjoint"
            }, {
                "max": 2,
                "plural": "enfants",
                "key": "enfant",
                "label": "Enfants"
            }, {
                "plural": "autres",
                "key": "autre",
                "label": "Autres"
            }],
            "label": "Logement principal"
        }
    },
    "method": "/api/2/entities",
    "params": {
        "context": null,
        "reforms": []
    }
}
```
