### PR TITLE
Add `entity.key` and `entity.plural` to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+* Add `entity.key` and `entity.plural` to JSON returned by `/2/entities` endpoint.
+
 ## 3.0.0
 
 * Adapt parsers to core#v4

--- a/openfisca_web_api/controllers/__init__.py
+++ b/openfisca_web_api/controllers/__init__.py
@@ -35,7 +35,7 @@ def make_router():
         ('GET', '^/$', index),
         ('GET', '^/api/?$', index),
         ('POST', '^/api/1/calculate/?$', calculate.api1_calculate),
-        ('GET', '^/api/2/entities/?$', entities.api1_entities),
+        ('GET', '^/api/2/entities/?$', entities.api2_entities),
         ('GET', '^/api/1/field/?$', field.api1_field),
         ('GET', '^/api/1/fields/?$', fields.api1_fields),
         ('GET', '^/api/1/formula/(?P<name>[^/]+)/?$', formula.api1_formula),

--- a/openfisca_web_api/controllers/entities.py
+++ b/openfisca_web_api/controllers/entities.py
@@ -10,7 +10,11 @@ from .. import contexts, conv, model, wsgihelpers
 
 
 def build_entity_data(entity):
-    entity_data = {'label': entity.label}
+    entity_data = {
+        'key': entity.key,
+        'label': entity.label,
+        'plural': entity.plural
+        }
     if entity.is_person:
         entity_data['isPersonsEntity'] = entity.is_person
     else:

--- a/openfisca_web_api/controllers/entities.py
+++ b/openfisca_web_api/controllers/entities.py
@@ -21,7 +21,7 @@ def build_entity_data(entity):
 
 
 @wsgihelpers.wsgify
-def api1_entities(req):
+def api2_entities(req):
     ctx = contexts.Ctx(req)
     headers = wsgihelpers.handle_cross_origin_resource_sharing(ctx)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '3.0.0',
+    version = '3.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Replaces https://github.com/openfisca/openfisca-web-api/pull/73

Cancels https://github.com/openfisca/openfisca-core/pull/425

Necessary for the demonstrator which I'm porting to the syntax of the Core v4, which modified `/api/2/entities`, but not enough JSON data was returned.