### PR TITLE
Fix the condition to detect if the country package has decompositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.0.2
+
+* Fix the condition to detect if the country package has decompositions:
+    * Load decompositions only if `tax_benefit_system` has a `decomposition_file_path` attribute.
+
 ## 3.0.1
 
 * Rename variables to make the tests pass.

--- a/openfisca_web_api/controllers/simulate.py
+++ b/openfisca_web_api/controllers/simulate.py
@@ -197,7 +197,7 @@ def api1_simulate(req):
             headers = headers,
             )
 
-    decomposition_json = model.get_cached_or_new_decomposition_json(tax_benefit_system = base_tax_benefit_system)
+    decomposition_json = model.get_cached_or_new_decomposition_json(base_tax_benefit_system)
     base_simulations = [scenario.new_simulation(trace = data['trace']) for scenario in base_scenarios]
 
     try:
@@ -220,9 +220,7 @@ def api1_simulate(req):
             )
 
     if data['reforms'] is not None:
-        reform_decomposition_json = model.get_cached_or_new_decomposition_json(
-            tax_benefit_system = reform_tax_benefit_system,
-            )
+        reform_decomposition_json = model.get_cached_or_new_decomposition_json(reform_tax_benefit_system)
         reform_simulations = [scenario.new_simulation(trace = data['trace']) for scenario in reform_scenarios]
         try:
             reform_response_json = decompositions.calculate(reform_simulations, reform_decomposition_json)

--- a/openfisca_web_api/environment.py
+++ b/openfisca_web_api/environment.py
@@ -149,7 +149,8 @@ def load_environment(global_conf, app_conf):
             model.reformed_tbs[full_key] = reformed_tbs
 
     log.debug(u'Cache default decomposition.')
-    if hasattr(tax_benefit_system, 'DEFAULT_DECOMP_FILE'):
+    if tax_benefit_system.decomposition_file_path is not None:
+        # Ignore the returned value, because we just want to pre-compute the cache.
         model.get_cached_or_new_decomposition_json(tax_benefit_system)
 
     log.debug(u'Initialize lib2to3-based input variables extractor.')

--- a/openfisca_web_api/model.py
+++ b/openfisca_web_api/model.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import os
-
 from openfisca_core import decompositions
 from openfisca_core.reforms import Reform, compose_reforms
 
@@ -33,15 +31,13 @@ def get_cached_composed_reform(reform_keys, tax_benefit_system):
     return composed_reform_tbs
 
 
-def get_cached_or_new_decomposition_json(tax_benefit_system, xml_file_name = None):
-    if xml_file_name is None:
-        xml_file_name = tax_benefit_system.DEFAULT_DECOMP_FILE
+def get_cached_or_new_decomposition_json(tax_benefit_system):
+    xml_file_path = tax_benefit_system.decomposition_file_path
     global decomposition_json_by_file_path_cache
-    decomposition_json = decomposition_json_by_file_path_cache.get(xml_file_name)
+    decomposition_json = decomposition_json_by_file_path_cache.get(xml_file_path)
     if decomposition_json is None:
-        xml_file_path = os.path.join(tax_benefit_system.DECOMP_DIR, xml_file_name)
         decomposition_json = decompositions.get_decomposition_json(tax_benefit_system, xml_file_path)
-        decomposition_json_by_file_path_cache[xml_file_name] = decomposition_json
+        decomposition_json_by_file_path_cache[xml_file_path] = decomposition_json
     return decomposition_json
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core >= 4.0.0b1, < 5.0',
+        'OpenFisca-Core >= 4.3.5, < 5.0',
         'OpenFisca-Parsers >= 1.0.0, < 2.0',
         'PasteDeploy',
         'WebError >= 0.10',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '3.0.1',
+    version = '3.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Connected to #76.

Replaces #81 

Due to openfisca/openfisca-core#450, any `TaxBenefitSystem` has a `decomposition_file_path` attribute.

Comes after #92 because this PR needs OpenFisca-France >= 13.y.z.
