### PR TITLE
Rename variables to follow France evolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.1
 
 * Rename variables to make the tests pass.
+* Remove the dependency constraint to France.
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+* Rename variables to make the tests pass.
+
 ## 3.0.0
 
 * Adapt parsers to core#v4

--- a/examples/calculate_single_person_1.json
+++ b/examples/calculate_single_person_1.json
@@ -27,5 +27,5 @@
       "period": "2015"
     }
   ],
-  "variables": ["revdisp"]
+  "variables": ["revenu_disponible"]
 }

--- a/examples/calculate_single_person_2.json
+++ b/examples/calculate_single_person_2.json
@@ -8,5 +8,5 @@
     }
   ],
   "output_format": "variables",
-  "variables": ["revdisp"]
+  "variables": ["revenu_disponible"]
 }

--- a/openfisca_web_api/controllers/field.py
+++ b/openfisca_web_api/controllers/field.py
@@ -54,7 +54,7 @@ def api1_field(req):
             dict(
                 variable = conv.pipe(
                     conv.empty_to_none,
-                    conv.default(u'revdisp'),
+                    conv.default(u'revenu_disponible'),
                     conv.test_in(tax_benefit_system.column_by_name),
                     ),
                 ),

--- a/openfisca_web_api/controllers/graph.py
+++ b/openfisca_web_api/controllers/graph.py
@@ -66,7 +66,7 @@ def api1_graph(req):
             dict(
                 variable = conv.pipe(
                     conv.empty_to_none,
-                    conv.default(u'revdisp'),
+                    conv.default(u'revenu_disponible'),
                     conv.test_in(tax_benefit_system.column_by_name),
                     ),
                 ),

--- a/openfisca_web_api/tests/test_calculate.py
+++ b/openfisca_web_api/tests/test_calculate.py
@@ -59,7 +59,7 @@ def test_calculate_with_test_case():
                 'period': '2013',
                 },
             ],
-        'variables': ['revdisp'],
+        'variables': ['revenu_disponible'],
         }
     req = Request.blank(
         '/api/1/calculate',
@@ -115,7 +115,7 @@ def test_calculate_with_axes():
                     }],
                 },
             }],
-        'variables': ['impo']
+        'variables': ['impots_directs']
         }
     req = Request.blank(
         '/api/1/calculate',
@@ -126,7 +126,7 @@ def test_calculate_with_axes():
     res = req.get_response(common.app)
     assert_equal(res.status_code, 200, res.body)
     res_body_json = json.loads(res.body)
-    impo_values = res_body_json['value'][0]['impo']['2014']
+    impo_values = res_body_json['value'][0]['impots_directs']['2014']
     assert_is_instance(impo_values, list)
     assert_true(impo_values[-1] < 0)
 

--- a/openfisca_web_api/tests/test_swagger.py
+++ b/openfisca_web_api/tests/test_swagger.py
@@ -118,21 +118,31 @@ def test_map_type_to_swagger_enum():
 
 
 def test_map_parameters_to_swagger():
-    target_column = model.tax_benefit_system.column_by_name['revdisp']
+    target_column = model.tax_benefit_system.column_by_name['revenu_disponible']
 
     actual = [
         description.get('name')
         for description in map_parameters_to_swagger(target_column)
         ]
 
-    assert_equal(actual, ['ppe', 'rev_trav', 'rev_cap', 'pen', 'psoc', 'impo'])
+    assert_equal(
+        actual,
+        [
+            u'revenus_du_travail',
+            u'ppe',
+            u'impots_directs',
+            u'pensions',
+            u'prestations_sociales',
+            u'revenus_du_capital',
+            ]
+        )
 
 
 def test_map_parameter_to_swagger():
-    target_column = model.tax_benefit_system.column_by_name['rev_cap']
+    target_column = model.tax_benefit_system.column_by_name['revenus_du_capital']
 
     expected = {
-        'name': u'rev_cap',
+        'name': u'revenus_du_capital',
         'description': u'Revenus du patrimoine',
         'in': 'query',
         'type': 'number',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '3.0.0',
+    version = '3.0.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,6 @@ setup(
         'paster': [
             'PasteScript',
             ],
-        'france': [
-            'OpenFisca-France >= 5.0.0, < 7.0',
-            ],
         'test': [
             'nose',
             ],


### PR DESCRIPTION
Comes before #91 

A few variables are hard-coded in tests, and I'm pretty sure that's the only reason for having an explicit dependency constraint to France.

Then we'll be able to merge #91 because it needs on OpenFisca-France == 13.y.z.