### PR TITLE
Fix country path in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1
+
+* Bugfix: in development mode, fix the path of the country package. This impacts the `parameters` endpoint.
+
 ## 3.1.0
 
 * Accept other countries than OpenFisca-France and OpenFisca-Tunisia.

--- a/openfisca_web_api/environment.py
+++ b/openfisca_web_api/environment.py
@@ -153,9 +153,12 @@ def load_environment(global_conf, app_conf):
         model.input_variables_extractor = input_variables_extractors.setup(tax_benefit_system)
 
     global country_package_dir_path
-    # Using pkg_resources.get_distribution(conf["country_package"]).location
-    # returns a wrong path in virtualenvs (<venv>/lib versus <venv>/local/lib).
-    country_package_dir_path = country_package.__path__[0]
+    # - Do not use pkg_resources.get_distribution(conf["country_package"]).location
+    #   because it returns a wrong path in virtualenvs (<venv>/lib versus <venv>/local/lib)
+    # - Use os.path.abspath because when the web API is runned in development with "paster serve",
+    #   __path__[0] == 'openfisca_france' for example. Then, get_relative_file_path won't be able
+    #   to find the relative path of an already relative path.
+    country_package_dir_path = os.path.abspath(country_package.__path__[0])
 
     global api_package_version
     api_package_version = pkg_resources.get_distribution('openfisca_web_api').version

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '3.1.0',
+    version = '3.1.1',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
Bugfix: in development mode (with `paster serve`), fix the path of the country package.

This impacts the `parameters` endpoint.

Before:
```json
{"xml_file_path": "penfisca/openfisca_france/parameters/__root__.xml"}
```
`xml_file_path` is intended to be relative of the directory of the Python package (ie `/home/.../openfisca-france/openfisca_france`).

Its value should be:
```json
{"xml_file_path": "parameters/__root__.xml"}
```

This is the fix: getting the absolute path of the country package directory helps finding the relative path of the XML file (which is an absolute path).