### PR TITLE
Internationalise openfisca-serve script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.2.0
+
+* Make the script `openfisca-serve` work with any country
+    - Before, it was always loading `openfisca-france`
+    - Now, the country package (as well as reforms and extensions) can be provided through arguments
+    - If no country package is provided, an auto-detection is attempted
+
+For more information about how to use the script, run `openfisca-serve -h`.
+
 ## 3.1.1
 
 * Bugfix: in development mode, fix the path of the country package. This impacts the `parameters` endpoint.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '3.1.1',
+    version = '3.2.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [


### PR DESCRIPTION
* Make the script `openfisca-serve` work with any country
     - Before, it was always loading `openfisca-france`
     - Now, the country package (as well as reforms and extensions) can be provided through arguments
     - If no country package is provided, an auto-detection is attempted
 
 For more information about how to use the script, run `openfisca-serve -h`.

--------

Usage :

```sh
openfisca-serve # will attempt an auto detection of the country package
openfisca-serve -c openfisca_senegal -p 14000
openfisca-serve -e openfisca_paris -r openfisca_france.reforms.aides_cd93.aides_cd93
```

--------------

Todo : 

- [ ] Update the [gitbook doc](https://github.com/openfisca/openfisca-gitbook/blob/master/openfisca-web-api/install_an_api_instance.md#run)

- - - -

Fixes #80.