### PR TITLE
Clean Continuous Integration config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python: 2.7
 cache: pip
 install:
   - pip install --upgrade pip wheel  # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
-  - pip install flake8
   - pip install "OpenFisca-France==15.1.0"  # Needed only for tests.
   - pip install --editable .[test]
 script: ./travis-run-tests.sh

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
             'PasteScript',
             ],
         'test': [
+            'flake8',
             'nose',
             ],
         },


### PR DESCRIPTION
Move flake8 to setup.py "test" extra require.

The reason is to be consistent with https://github.com/openfisca/openfisca-france/pull/713