### PR TITLE
Handle errors in calculate and simulate endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.0.0
+
+* Breaking change: Adapt Web-API to OpenFisca-Core 10
+
+* Technical change: return the error message to the user instead of a generic "Server Error".
+    - Impacts `calculate` and `simulate` endpoints.
+    - In particular when a wrong period is specified for an input variable in the JSON payload
+ 
 ## 4.0.0
 
 * Restrict the accepted formats to define a period
@@ -13,6 +21,7 @@
 ## 3.3.1
 
 * Technical and not breaking change
+  - Move JSON representation of entities to the Core for code factorization
 
 ## 3.3.0
 

--- a/openfisca_web_api/controllers/calculate.py
+++ b/openfisca_web_api/controllers/calculate.py
@@ -357,9 +357,12 @@ def api1_calculate(req):
 
     trace_simulations = data['trace'] or data['intermediate_variables']
 
-    base_simulations = calculate_simulations(scenarios, data['variables'], trace = trace_simulations)
-    if data['reforms'] is not None:
-        reform_simulations = calculate_simulations(reform_scenarios, data['variables'], trace = trace_simulations)
+    try:
+        base_simulations = calculate_simulations(scenarios, data['variables'], trace = trace_simulations)
+        if data['reforms'] is not None:
+            reform_simulations = calculate_simulations(reform_scenarios, data['variables'], trace = trace_simulations)
+    except ValueError as exc:
+        wsgihelpers.handle_error(exc, ctx, headers)
 
     calculate_simulation_end_time = time.time()
     calculate_simulation_time = calculate_simulation_end_time - calculate_simulation_start_time

--- a/openfisca_web_api/controllers/simulate.py
+++ b/openfisca_web_api/controllers/simulate.py
@@ -205,7 +205,10 @@ def api1_simulate(req):
             )
 
     decomposition_json = model.get_cached_or_new_decomposition_json(base_tax_benefit_system)
-    base_simulations = [scenario.new_simulation(trace = data['trace']) for scenario in base_scenarios]
+    try:
+        base_simulations = [scenario.new_simulation(trace = data['trace']) for scenario in base_scenarios]
+    except ValueError as exc:
+        wsgihelpers.handle_error(exc, ctx, headers)
 
     try:
         base_response_json = decompositions.calculate(base_simulations, decomposition_json)
@@ -228,7 +231,11 @@ def api1_simulate(req):
 
     if data['reforms'] is not None:
         reform_decomposition_json = model.get_cached_or_new_decomposition_json(reform_tax_benefit_system)
-        reform_simulations = [scenario.new_simulation(trace = data['trace']) for scenario in reform_scenarios]
+        try:
+            reform_simulations = [scenario.new_simulation(trace = data['trace']) for scenario in reform_scenarios]
+        except ValueError as exc:
+            wsgihelpers.handle_error(exc, ctx, headers)
+
         try:
             reform_response_json = decompositions.calculate(reform_simulations, reform_decomposition_json)
         except ParameterNotFound as exc:

--- a/openfisca_web_api/tests/test_calculate.py
+++ b/openfisca_web_api/tests/test_calculate.py
@@ -3,7 +3,7 @@
 
 import json
 
-from nose.tools import assert_equal, assert_is_instance, assert_true
+from nose.tools import assert_equal, assert_in, assert_is_instance, assert_true
 from webob import Request
 
 from . import common
@@ -327,3 +327,45 @@ def test_calculate_with_trace():
     assert_is_instance(first_traceback, dict)
     traceback_with_parameters = next(item for item in first_scenario_tracebacks if item.get('parameters'))
     assert_is_instance(traceback_with_parameters['parameters'], list)
+
+
+def test_calculate_with_wrong_input_variable_period():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0', 'enfant_a_charge': {"2013-01": 15000}},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    assert_in(u'ValueError: Unable to set a value for variable', res.body, res.body)

--- a/openfisca_web_api/tests/test_calculate.py
+++ b/openfisca_web_api/tests/test_calculate.py
@@ -342,10 +342,12 @@ def test_calculate_with_wrong_input_variable_period():
                     'foyers_fiscaux': [
                         {
                             'declarants': ['ind0', 'ind1'],
+                            # rfr is defined for a year, its value can't be set for a month
+                            'rfr': {"2013-01": 15000},
                             },
                         ],
                     'individus': [
-                        {'id': 'ind0', 'enfant_a_charge': {"2013-01": 15000}},
+                        {'id': 'ind0'},
                         {'id': 'ind1'},
                         ],
                     'menages': [
@@ -369,4 +371,557 @@ def test_calculate_with_wrong_input_variable_period():
     res = req.get_response(common.app)
     assert_equal(res.status_code, 400, res.body)
     res_body_json = json.loads(res.body)
-    assert_in(u'ValueError: Unable to set a value for variable', res_body_json['error']['message'], res.body)
+    assert_in(
+        u'ValueError: Unable to set a value for variable rfr for month-long period 2013-01',
+        res_body_json['error']['message'],
+        res.body,
+        )
+
+
+def test_calculate_with_wrong_variable_period():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013-01',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(
+        u'ValueError: Unable to compute variable revenu_disponible for period 2013-01',
+        res_body_json['error']['message'],
+        res.body,
+        )
+
+
+def test_calculate_with_wrong_input_variable():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0', 'i_do_not_exist': 42},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(
+        u'VariableNotFound: You tried to calculate or to set a value for variable \'i_do_not_exist\'',
+        res_body_json['error']['message'],
+        res.body,
+        )
+
+
+def test_calculate_with_wrong_variable():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['i_do_not_exist'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(
+        u'VariableNotFound: You tried to calculate or to set a value for variable \'i_do_not_exist\'',
+        res_body_json['error']['message'],
+        res.body,
+        )
+
+
+def test_calculate_with_wrong_input_period_string():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0', 'enfant_a_charge': {'i_am_a_wrong_period': 42}},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(u'ValueError: Invalid period i_am_a_wrong_period', res_body_json['error']['message'], res.body)
+
+
+def test_calculate_with_wrong_input_period_none():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0', 'enfant_a_charge': {None: 42}},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(u'ValueError: Invalid period null', res_body_json['error']['message'], res.body)
+
+
+def test_calculate_with_wrong_period_string():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': 'i_am_a_wrong_period_string',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(u'ValueError: Invalid period i_am_a_wrong_period_string', res_body_json['error']['message'], res.body)
+
+
+def test_calculate_with_wrong_period_list():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': ['i_am_a_wrong_period_list'],
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(
+        u'ValueError: Invalid period',
+        res_body_json['error']['message'],
+        res.body,
+        )
+
+
+def test_calculate_with_input_variable_set_to_wrong_entity():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            'salaire_imposable': 42,
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(
+        u'ValueError: Variable salaire_imposable is defined for entity individu.',
+        res_body_json['error']['message'],
+        res.body,
+        )
+
+
+def test_calculate_with_variable_with_set_input_and_inconsistent_input_data():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            'loyer': {
+                                '2013': 12000,
+                                'month:2013-01:12': 1000,
+                                },
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(
+        u'ValueError: Inconsistent input: variable loyer has already been set for all months '
+        u'contained in period 2013, and value [ 12000.] provided for 2013 doesn\'t match the total ([ 999.99609375]).',
+        res_body_json['error']['message'],
+        res.body,
+        )
+
+
+def test_calculate_with_wrong_entity_name():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'i_am_a_wrong_entity': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(u'ValueError: Invalid entity name: i_am_a_wrong_entity', res_body_json['error']['message'], res.body)
+
+
+def test_calculate_with_wrong_value_type():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0', 'salaire_imposable': [15000]},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(
+        u'ValueError: Invalid value [15000] for variable salaire_imposable.',
+        res_body_json['error']['message'], res.body
+        )
+
+
+def test_calculate_with_wrong_id_type():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'individus': [
+                        {'id': {'k': 'ind0'}},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        'variables': ['revenu_disponible'],
+        }
+    req = Request.blank(
+        '/api/1/calculate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(u'ValueError: Invalid id in entity', res_body_json['error']['message'], res.body)

--- a/openfisca_web_api/tests/test_calculate.py
+++ b/openfisca_web_api/tests/test_calculate.py
@@ -368,4 +368,5 @@ def test_calculate_with_wrong_input_variable_period():
         )
     res = req.get_response(common.app)
     assert_equal(res.status_code, 400, res.body)
-    assert_in(u'ValueError: Unable to set a value for variable', res.body, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(u'ValueError: Unable to set a value for variable', res_body_json['error']['message'], res.body)

--- a/openfisca_web_api/tests/test_simulate.py
+++ b/openfisca_web_api/tests/test_simulate.py
@@ -113,4 +113,5 @@ def test_simulate_with_wrong_input_variable_period():
         )
     res = req.get_response(common.app)
     assert_equal(res.status_code, 400, res.body)
-    assert_in(u'ValueError: Unable to set a value for variable', res.body, res.body)
+    res_body_json = json.loads(res.body)
+    assert_in(u'ValueError: Unable to set a value for variable', res_body_json['error']['message'], res.body)

--- a/openfisca_web_api/tests/test_simulate.py
+++ b/openfisca_web_api/tests/test_simulate.py
@@ -71,3 +71,46 @@ def test_simulate_with_test_case():
     res_body_json = json.loads(res.body)
     assert_not_in('error', res_body_json)
     assert_in('value', res_body_json)
+
+
+def test_simulate_with_wrong_input_variable_period():
+    test_case = {
+        'scenarios': [
+            {
+                'test_case': {
+                    'familles': [
+                        {
+                            'parents': ['ind0', 'ind1'],
+                            },
+                        ],
+                    'foyers_fiscaux': [
+                        {
+                            'declarants': ['ind0', 'ind1'],
+                            # rfr is defined for a year, its value can't be set for a month
+                            'rfr': {"2013-01": 15000},
+                            },
+                        ],
+                    'individus': [
+                        {'id': 'ind0'},
+                        {'id': 'ind1'},
+                        ],
+                    'menages': [
+                        {
+                            'conjoint': 'ind1',
+                            'personne_de_reference': 'ind0',
+                            },
+                        ],
+                    },
+                'period': '2013',
+                },
+            ],
+        }
+    req = Request.blank(
+        '/api/1/simulate',
+        body = json.dumps(test_case),
+        headers = (('Content-Type', 'application/json'),),
+        method = 'POST',
+        )
+    res = req.get_response(common.app)
+    assert_equal(res.status_code, 400, res.body)
+    assert_in(u'ValueError: Unable to set a value for variable', res.body, res.body)

--- a/openfisca_web_api/wsgihelpers.py
+++ b/openfisca_web_api/wsgihelpers.py
@@ -132,7 +132,7 @@ def handle_error(error, ctx, headers):
         dict(
             error = dict(
                 code = 400,
-                errors = u"{}: {}".format(error.__class__.__name__, error.message),
+                message = u"{}: {}".format(error.__class__.__name__, error.message),
                 ),
             ),
         headers = headers,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '4.0.0',
+    version = '5.0.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11',
-        'OpenFisca-Core[parsers] >= 9.0, < 10.0',
+        'OpenFisca-Core[parsers] >= 10.0.1, < 11.0',
         'PasteDeploy',
         'WebError >= 0.10',
         'WebOb >= 1.1',


### PR DESCRIPTION
Connected to #110 

Follows https://github.com/openfisca/openfisca-core/pull/486

`Scenario.new_simulation` can raise `ValueError` corresponding to period mismatch.

This PR catches and returns them to the client in JSON.

This introduces catch-all `try/except` but we agree it's not a problem (see discussion from [this comment](https://github.com/openfisca/openfisca-web-api/issues/110#issuecomment-288719195)).

---

EDIT:

Error received by the client before PR:

```json
{
  "error": {
    "message": "An internal server error occurred",
    "code": 500,
    "hint": "See the HTTP server log to see the exception traceback."
  }
}
```

Error received by the client after PR:

```json
{
  "error": {
    "message": "ValueError: Unable to set a value for variable enfant_a_charge for month-long period 2017-02. enfant_a_charge is only defined for years. Please adapt your input. If you are the maintainer of enfant_a_charge, you can consider adding it a set_input attribute to enable automatic period casting.",
    "code": 400
  }
}
```