### PR TITLE
Deploy API continuously

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ COUNTRY_PACKAGE=openfisca_france gunicorn "openfisca_web_api.app:create_app()" -
 ```
 
 The `--workers k` (with `k >= 3`) option is necessary to avoid [this issue](http://stackoverflow.com/questions/11150343/slow-requests-on-local-flask-server). Without it, AJAX requests from Chrome sometimes take more than 20s to process.
+
+## Deploy
+
+```sh
+ssh deploy-new-api@api-test.openfisca.fr
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ nosetests
 ## Run
 
 ```sh
-COUNTRY_PACKAGE=openfisca_france FLASK_APP=openfisca_web_api/server.py flask run --with-threads
+COUNTRY_PACKAGE=openfisca_france gunicorn "openfisca_web_api.app:create_app()" --bind localhost:5000 --workers 3
 ```
 
-The `--with-threads` is necessary to avoid [this issue](https://github.com/corydolphin/flask-cors/issues/147#issuecomment-289539799). Without it, AJAX requests from Chrome sometimes take more than 20s to process.
+The `--workers k` (with `k >= 3`) option is necessary to avoid [this issue](http://stackoverflow.com/questions/11150343/slow-requests-on-local-flask-server). Without it, AJAX requests from Chrome sometimes take more than 20s to process.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ git checkout rewrite
 pip install -e ".[test]"
 ```
 
+Install OpenFisca-France as well if you need it:
+
+```sh
+pip install openfisca_france
+```
+
 ## Test
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # OpenFisca new Web-API
 
+This is the new OpenFisca web API, available at https://api-test.openfisca.fr/ (beta version).
+
 ## Install
 
 ```sh

--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,8 @@ dependencies:
 test:
   override:
     - make test
+deployment:
+  production:
+    branch: rewrite
+    commands:
+      - ssh deploy-new-api@api-test.openfisca.fr

--- a/openfisca_web_api/server.py
+++ b/openfisca_web_api/server.py
@@ -1,2 +1,0 @@
-from app import create_app
-app = create_app()

--- a/prod/deploy.sh
+++ b/prod/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -ex
+
+source /home/openfisca/virtualenvs/new-api/bin/activate
+cd /home/openfisca/new-api/openfisca-web-api
+git fetch origin rewrite
+git checkout origin/rewrite --force
+pip install --editable . --upgrade
+pip install openfisca_france --upgrade
+# The current user must have been specifically allowed to run the next command
+# Use the visudo command to do so
+sudo systemctl restart openfisca-web-api-new.service

--- a/prod/openfisca-web-api.service
+++ b/prod/openfisca-web-api.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OpenFisca Web API
+
+[Service]
+Environment=COUNTRY_PACKAGE=openfisca_france
+ExecStart=/home/openfisca/virtualenvs/new-api/bin/gunicorn "openfisca_web_api.app:create_app()" --workers 3 --bind localhost:6000
+User=openfisca
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     install_requires=[
         'flask == 0.12',
         'flask-cors == 3.0.2',
+        'gunicorn >= 19.7.1',
         'OpenFisca-Core >= 8.0.0, < 10.0',
         ],
     packages=find_packages(exclude=['openfisca_web_api.tests*']),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/openfisca/openfisca-web-api/tree/rewrite',
     extras_require={
         'test': [
-            'Openfisca-Dummy-Country >= 0.1.1',
+            'Openfisca-Dummy-Country == 0.1.1',
             'nose',
             'flake8',
             ],


### PR DESCRIPTION
Connected to #106 

Once merged:
- [ ] Replace the hardcoded `deploy.sh` on the server by a symlink.