### PR TITLE
Install requirements from ops

### DIFF
--- a/prod/deploy.sh
+++ b/prod/deploy.sh
@@ -7,7 +7,7 @@ cd /home/openfisca/new-api/openfisca-web-api
 git fetch origin rewrite
 git checkout origin/rewrite --force
 pip install --editable . --upgrade
-pip install openfisca_france --upgrade
+pip install --requirement /home/openfisca/openfisca-ops/auto-update-pip-packages/requirements.txt --upgrade
 # The current user must have been specifically allowed to run the next command
 # Use the visudo command to do so
 sudo systemctl restart openfisca-web-api-new.service


### PR DESCRIPTION
Connected to openfisca/openfisca-ops#4

Install requirements from openfisca-ops in order to use the same version of France than the legacy web API.