### PR TITLE
Adapt web API to Core v16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
 install:
   - pip install --upgrade pip wheel  # pip >= 8.0 needed to be compatible with "manylinux" wheels, used by numpy >= 1.11
   - pip install "OpenFisca-France==18.5.3"  # Needed only for tests.
-  - pip install --editable .[test]
+  - pip install --editable ".[test, parsers]"
 script: ./travis-run-tests.sh
 before_deploy:
   - python setup.py compile_catalog

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'OpenFisca-Web-API',
-    version = '6.0.0',
+    version = '6.1.0',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [
@@ -49,12 +49,15 @@ setup(
             'flake8',
             'nose',
             ],
+        'parsers': [
+            'OpenFisca-Parsers >= 1.0.2, < 2.0',
+            ],
         },
     install_requires = [
         'Babel >= 0.9.4',
         'Biryani[datetimeconv] >= 0.10.4',
         'numpy >= 1.11, < 1.13',
-        'OpenFisca-Core[parsers] >= 14.1.2, < 16.0',
+        'OpenFisca-Core >= 14.1.2, < 17.0',
         'PasteDeploy',
         'WebError >= 0.10',
         'WebOb >= 1.1',


### PR DESCRIPTION
Connected to openfisca/openfisca-core#500

Parsers are now deprecated and not referenced in core anymore