### PR TITLE
Deprecate openfisca-web-api package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@
 **The official API is now available in [OpenFisca Core repository](https://github.com/openfisca/openfisca-core).**  
 **The current package isn't maintained anymore: it won't evolve, and it is not guaranteed to be compatible with future versions of OpenFisca.**
 
+The aim of this package was to provide OpenFisca information and computations through a web interface, without installing anything locally.
 
-[![Build Status](https://travis-ci.org/openfisca/openfisca-web-api.svg?branch=master)](https://travis-ci.org/openfisca/openfisca-web-api)
+However, after a few years of existence, it appeared:
+* That versioning OpenFisca API and the Core module apart was difficult to maintain
+* That this API endpoints needed to be improved to match users experiences
 
-[More build statuses](https://www.openfisca.fr/build-status)
+## Introduction
+
+[![Build Status](https://travis-ci.org/openfisca/openfisca-web-api.svg?branch=master)](https://travis-ci.org/openfisca/openfisca-web-api) - [More build statuses](https://www.openfisca.fr/build-status)
 
 [OpenFisca](https://www.openfisca.fr/) is a versatile microsimulation free software.
-This is the source code of the Web-API module.
+This is the source code of the deprecated Web-API module.
 
 The documentation of the project is hosted at http://openfisca.org/doc/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# OpenFisca Web-API
+# OpenFisca Web-API - DEPRECATED
+
+## This package is deprecated
+
+**The official API is now available in [OpenFisca Core repository](https://github.com/openfisca/openfisca-core).**  
+**The current package isn't maintained anymore: it won't evolve, and it is not guaranteed to be compatible with future versions of OpenFisca.**
+
 
 [![Build Status](https://travis-ci.org/openfisca/openfisca-web-api.svg?branch=master)](https://travis-ci.org/openfisca/openfisca-web-api)
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## This package is deprecated
 
-**The official API is now packaged in [OpenFisca Core repository](https://github.com/openfisca/openfisca-core).**  
-**The current package isn't maintained anymore.**
+**The new OpenFisca Web API is now packaged in [OpenFisca-Core](https://github.com/openfisca/openfisca-core).**  
+**This package isn't maintained anymore.**
 
 The aim of this package was to provide OpenFisca information and computations through a web interface, without installing anything locally.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## This package is deprecated
 
-**The official API is now available in [OpenFisca Core repository](https://github.com/openfisca/openfisca-core).**  
-**The current package isn't maintained anymore: it won't evolve, and it is not guaranteed to be compatible with future versions of OpenFisca.**
+**The official API is now packaged in [OpenFisca Core repository](https://github.com/openfisca/openfisca-core).**  
+**The current package isn't maintained anymore.**
 
 The aim of this package was to provide OpenFisca information and computations through a web interface, without installing anything locally.
 
@@ -12,8 +12,6 @@ However, after a few years of existence, it appeared:
 * That this API endpoints needed to be improved to match users experiences
 
 ## Introduction
-
-[![Build Status](https://travis-ci.org/openfisca/openfisca-web-api.svg?branch=master)](https://travis-ci.org/openfisca/openfisca-web-api) - [More build statuses](https://www.openfisca.fr/build-status)
 
 [OpenFisca](https://www.openfisca.fr/) is a versatile microsimulation free software.
 This is the source code of the deprecated Web-API module.


### PR DESCRIPTION
Connected to openfisca/openfisca-core#577

Add deprecation information to README.
Explain deprecation main reasons and add link to new API.